### PR TITLE
Board white lines fix for Chrome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 style.css.map
 style.css
+node_modules

--- a/css/components/_components.game.scss
+++ b/css/components/_components.game.scss
@@ -28,17 +28,15 @@
 .g-field {
     flex-grow: 1;
     flex-shrink: 1;
-    // border-right: 1px dotted red;
-    // border-bottom: 1px dotted red;
     width: 100%;
     position: relative;
     background: url('../img/grass.png') no-repeat center;
-    background-size: contain;
+    background-size: 101% 101%;
 }
 
 .g-field-1 {
     background: url('../img/grass1.png') no-repeat center;
-    background-size: contain;
+    background-size: 101% 101%;
 }
 
 .g-field:before {


### PR DESCRIPTION
Board white lines fix for Chrome

Changed:
`background-size: contain;`

This should get rid of vertical and horizontal lines when rescaling gameboard in chrome